### PR TITLE
Recreate dual-agent review assistant CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+config.json
+reviews/*
+!reviews/.gitkeep
+venv/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AI-Powered Review Assistant (Agent Pipeline Edition)
 
-An advanced, command-line tool that leverages a dual-agent AI pipeline to generate high-quality, context-aware product reviews. This assistant allows users to connect to multiple Large Language Model (LLM) providers, including Google's Gemini, Ollama, and LM Studio, to create nuanced and human-like reviews.
+An advanced, command-line tool that leverages a dual-agent AI pipeline to generate high-quality, context-aware product reviews. This assistant allows users to connect to multiple Large Language Model (LLM) providers, including Google's Gemini, OpenRouter, Ollama, and LM Studio, to create nuanced and human-like reviews.
 
 ---
 
@@ -16,7 +16,7 @@ This repository contains the full source code and documentation for the AI Revie
 ## Key Features
 
 * **Dual-Agent Pipeline:** Utilizes a "Writer" agent to generate an initial draft and a separate "Editor" agent to refine, humanize, and improve the final output.
-* **Multi-Provider Support:** Easily configure the application to use different LLMs for the writer and editor roles. Supports cloud-based models (Gemini) and locally-hosted models (Ollama, LM Studio).
+* **Multi-Provider Support:** Easily configure the application to use different LLMs for the writer and editor roles. Supports cloud-based models (Gemini, OpenRouter) and locally-hosted models (Ollama, LM Studio).
 * **Context-Aware Generation:** Can scrape a product's URL to gather real-time product information and analyze past reviews to generate new reviews that are consistent in tone and style.
 * **Simple CLI Interface:** A straightforward menu-driven interface for writing reviews, listing past reviews, and managing settings.
 * **Configurable & Extensible:** All settings, including API keys and model endpoints, are managed in a simple `config.json` file.
@@ -73,7 +73,7 @@ The following diagram illustrates the complete workflow of the application.
     * **1. Write a new review:** Provide a product name, rating, and notes to generate a review using the standard pipeline.
     * **2. Write a new review with product context:** Provide a product URL in addition to your notes to generate a more detailed and context-aware review.
     * **3. List past reviews:** View a list of all reviews you have saved in the `reviews/` directory.
-    * **4. Settings:** Configure which LLM provider to use for the "Writer" and "Editor" agents and enter your Gemini API key.
+    * **4. Settings:** Configure which LLM provider to use for the "Writer" and "Editor" agents and enter any required API keys.
     * **5. Exit:** Close the application.
 
 ---
@@ -97,12 +97,17 @@ The `config.json` file is the control center for the AI pipeline.
     },
     "lmstudio": {
       "endpoint": "http://localhost:1234/v1/chat/completions"
+    },
+    "openrouter": {
+      "api_key": "YOUR_API_KEY_HERE",
+      "model": "openrouter/auto"
     }
   }
 }
 ```
-* **`writer_provider` / `editor_provider`:** Can be set to `"gemini"`, `"ollama"`, or `"lmstudio"`.
-* **`api_key`:** If using Gemini, you must replace `"YOUR_API_KEY_HERE"` with your actual Google AI Studio API key.
+* **`writer_provider` / `editor_provider`:** Can be set to `"gemini"`, `"openrouter"`, `"ollama"`, or `"lmstudio"`.
+* **`api_key`:** Replace with your actual API key for Gemini or OpenRouter when those providers are used.
+* **`model`:** Specify the desired OpenRouter model (default `openrouter/auto`).
 * **`endpoint`:** Ensure the endpoints for Ollama or LM Studio match your local server configuration.
 
 ---

--- a/config.py
+++ b/config.py
@@ -1,0 +1,31 @@
+import json
+import os
+
+CONFIG_FILE = "config.json"
+
+DEFAULT_CONFIG = {
+    "pipeline": {
+        "writer_provider": "gemini",
+        "editor_provider": "lmstudio",
+    },
+    "providers": {
+        "gemini": {"api_key": "YOUR_API_KEY_HERE"},
+        "ollama": {"endpoint": "http://localhost:11434/api/generate"},
+        "lmstudio": {"endpoint": "http://localhost:1234/v1/chat/completions"},
+        "openrouter": {"api_key": "YOUR_API_KEY_HERE", "model": "openrouter/auto"},
+    },
+}
+
+
+def load_config():
+    """Load configuration from disk, creating default if missing."""
+    if not os.path.exists(CONFIG_FILE):
+        save_config(DEFAULT_CONFIG)
+    with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_config(cfg: dict) -> None:
+    """Persist configuration to disk."""
+    with open(CONFIG_FILE, "w", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=2)

--- a/fetcher.py
+++ b/fetcher.py
@@ -1,0 +1,15 @@
+"""Simple HTML fetcher to obtain basic product context."""
+import requests
+from bs4 import BeautifulSoup
+
+
+def fetch_product_context(url: str) -> str:
+    """Fetch minimal product information from a URL."""
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        soup = BeautifulSoup(resp.text, "html.parser")
+        title = soup.title.string.strip() if soup.title else ""
+        return f"Product page title: {title}" if title else ""
+    except Exception:
+        return ""

--- a/main.py
+++ b/main.py
@@ -1,0 +1,118 @@
+"""Command-line interface for the AI-Powered Review Assistant."""
+import datetime
+import os
+from typing import Optional
+
+from config import load_config, save_config
+from fetcher import fetch_product_context
+from pipeline import Agent, ReviewPipeline
+from providers import get_provider
+
+
+def slugify(name: str) -> str:
+    return "".join(c if c.isalnum() else "_" for c in name).strip("_").lower()
+
+
+def build_pipeline(cfg: dict) -> ReviewPipeline:
+    writer_name = cfg["pipeline"]["writer_provider"]
+    editor_name = cfg["pipeline"]["editor_provider"]
+    writer = Agent(get_provider(writer_name, cfg["providers"][writer_name]))
+    editor = Agent(get_provider(editor_name, cfg["providers"][editor_name]))
+    return ReviewPipeline(writer, editor)
+
+
+def ensure_reviews_dir() -> None:
+    os.makedirs("reviews", exist_ok=True)
+
+
+def write_review(with_context: bool = False) -> None:
+    cfg = load_config()
+    product = input("Product name: ").strip()
+    rating = input("Rating (1-5): ").strip()
+    notes = input("Notes: ").strip()
+
+    context = ""
+    if with_context:
+        url = input("Product URL: ").strip()
+        if url:
+            context = fetch_product_context(url)
+
+    pipeline = build_pipeline(cfg)
+    review_text = pipeline.run(notes, context)
+
+    ensure_reviews_dir()
+    filename = (
+        datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        + "_"
+        + slugify(product)
+        + ".txt"
+    )
+    with open(os.path.join("reviews", filename), "w", encoding="utf-8") as f:
+        f.write(f"Product: {product}\nRating: {rating}\n\n{review_text}\n")
+    print(f"Review saved to reviews/{filename}")
+
+
+def list_reviews() -> None:
+    ensure_reviews_dir()
+    files = sorted(os.listdir("reviews"))
+    if not files:
+        print("No reviews found.")
+        return
+    for f in files:
+        print(f)
+
+
+def settings_menu() -> None:
+    cfg = load_config()
+    print("Current writer provider:", cfg["pipeline"]["writer_provider"])
+    new_writer = input(
+        "Enter writer provider (gemini/ollama/lmstudio/openrouter) or blank to keep: "
+    ).strip().lower()
+    if new_writer:
+        cfg["pipeline"]["writer_provider"] = new_writer
+    print("Current editor provider:", cfg["pipeline"]["editor_provider"])
+    new_editor = input(
+        "Enter editor provider (gemini/ollama/lmstudio/openrouter) or blank to keep: "
+    ).strip().lower()
+    if new_editor:
+        cfg["pipeline"]["editor_provider"] = new_editor
+    if "gemini" in {cfg["pipeline"]["writer_provider"], cfg["pipeline"]["editor_provider"]}:
+        key = input("Enter Gemini API key (blank to keep current): ").strip()
+        if key:
+            cfg["providers"]["gemini"]["api_key"] = key
+    if "openrouter" in {cfg["pipeline"]["writer_provider"], cfg["pipeline"]["editor_provider"]}:
+        key = input("Enter OpenRouter API key (blank to keep current): ").strip()
+        if key:
+            cfg["providers"]["openrouter"]["api_key"] = key
+        model = input("Enter OpenRouter model (blank to keep current): ").strip()
+        if model:
+            cfg["providers"]["openrouter"]["model"] = model
+    save_config(cfg)
+    print("Configuration saved.")
+
+
+def main() -> None:
+    while True:
+        print("\nAI Review Assistant")
+        print("1. Write a new review")
+        print("2. Write a new review with product context")
+        print("3. List past reviews")
+        print("4. Settings")
+        print("5. Exit")
+        choice = input("Select an option: ").strip()
+        if choice == "1":
+            write_review(False)
+        elif choice == "2":
+            write_review(True)
+        elif choice == "3":
+            list_reviews()
+        elif choice == "4":
+            settings_menu()
+        elif choice == "5":
+            break
+        else:
+            print("Invalid choice. Please try again.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,0 +1,32 @@
+"""Agent pipeline orchestrating writer and editor steps."""
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class Provider(Protocol):
+    def generate(self, prompt: str) -> str:
+        ...
+
+
+@dataclass
+class Agent:
+    provider: Provider
+
+    def run(self, prompt: str) -> str:
+        return self.provider.generate(prompt)
+
+
+@dataclass
+class ReviewPipeline:
+    writer: Agent
+    editor: Agent
+
+    def run(self, notes: str, context: str = "") -> str:
+        prompt = f"Write a product review. Notes: {notes}\n{context}".strip()
+        draft = self.writer.run(prompt)
+        edit_prompt = (
+            "Improve, humanize, and polish the following product review.\n"
+            f"{draft}"
+        )
+        final = self.editor.run(edit_prompt)
+        return final

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -1,0 +1,18 @@
+"""LLM provider factory."""
+from .gemini_provider import GeminiProvider
+from .ollama_provider import OllamaProvider
+from .lmstudio_provider import LMStudioProvider
+from .openrouter_provider import OpenRouterProvider
+
+
+def get_provider(name: str, cfg: dict):
+    name = name.lower()
+    if name == "gemini":
+        return GeminiProvider(cfg.get("api_key"))
+    if name == "ollama":
+        return OllamaProvider(cfg.get("endpoint"))
+    if name == "lmstudio":
+        return LMStudioProvider(cfg.get("endpoint"))
+    if name == "openrouter":
+        return OpenRouterProvider(cfg.get("api_key"), cfg.get("model"))
+    raise ValueError(f"Unknown provider: {name}")

--- a/providers/gemini_provider.py
+++ b/providers/gemini_provider.py
@@ -1,0 +1,20 @@
+"""Provider wrapper for Google's Gemini models."""
+from typing import Optional
+
+import google.generativeai as genai
+
+
+class GeminiProvider:
+    def __init__(self, api_key: Optional[str]):
+        self.api_key = api_key
+        if api_key:
+            genai.configure(api_key=api_key)
+            self.model = genai.GenerativeModel("gemini-pro")
+        else:
+            self.model = None
+
+    def generate(self, prompt: str) -> str:
+        if not self.model:
+            raise RuntimeError("Gemini API key not configured")
+        response = self.model.generate_content(prompt)
+        return getattr(response, "text", "")

--- a/providers/lmstudio_provider.py
+++ b/providers/lmstudio_provider.py
@@ -1,0 +1,24 @@
+"""Provider wrapper for LM Studio's OpenAI-compatible endpoint."""
+from typing import Optional
+
+import requests
+
+
+class LMStudioProvider:
+    def __init__(self, endpoint: Optional[str]):
+        self.endpoint = endpoint
+
+    def generate(self, prompt: str) -> str:
+        if not self.endpoint:
+            raise RuntimeError("LM Studio endpoint not configured")
+        payload = {
+            "model": "default",
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        resp = requests.post(self.endpoint, json=payload, timeout=60)
+        resp.raise_for_status()
+        data = resp.json()
+        try:
+            return data["choices"][0]["message"]["content"].strip()
+        except Exception:
+            return ""

--- a/providers/ollama_provider.py
+++ b/providers/ollama_provider.py
@@ -1,0 +1,18 @@
+"""Provider wrapper for local Ollama server."""
+from typing import Optional
+
+import requests
+
+
+class OllamaProvider:
+    def __init__(self, endpoint: Optional[str]):
+        self.endpoint = endpoint
+
+    def generate(self, prompt: str) -> str:
+        if not self.endpoint:
+            raise RuntimeError("Ollama endpoint not configured")
+        payload = {"prompt": prompt}
+        resp = requests.post(self.endpoint, json=payload, timeout=60)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("response") or data.get("output", "")

--- a/providers/openrouter_provider.py
+++ b/providers/openrouter_provider.py
@@ -1,0 +1,30 @@
+"""Provider wrapper for OpenRouter's OpenAI-compatible API."""
+from typing import Optional
+
+import requests
+
+
+class OpenRouterProvider:
+    def __init__(self, api_key: Optional[str], model: str = "openrouter/auto"):
+        self.api_key = api_key
+        self.model = model or "openrouter/auto"
+        self.endpoint = "https://openrouter.ai/api/v1/chat/completions"
+
+    def generate(self, prompt: str) -> str:
+        if not self.api_key:
+            raise RuntimeError("OpenRouter API key not configured")
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        resp = requests.post(self.endpoint, headers=headers, json=payload, timeout=60)
+        resp.raise_for_status()
+        data = resp.json()
+        try:
+            return data["choices"][0]["message"]["content"].strip()
+        except Exception:
+            return ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+google-generativeai
+requests
+beautifulsoup4


### PR DESCRIPTION
## Summary
- add configurable dual-agent review pipeline with writer and editor roles
- support multiple LLM providers (Gemini, Ollama, LM Studio, OpenRouter)
- include CLI for generating reviews, managing settings, and fetching product context

## Testing
- `python -m py_compile $(find . -name '*.py' -print)`
- `pip install -r requirements.txt`
- `python main.py` then exit


------
https://chatgpt.com/codex/tasks/task_b_68bc4141376c8331b89ce14f85a734db